### PR TITLE
Add CLAUDE.md, devcontainer, and Claude Code hooks for web sessions

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Hook: PostToolUse
+# Fires after every tool call. Receives the tool output as JSON on stdin.
+#
+# Stub — no post-tool action needed for libro-client development.
+
+set -euo pipefail
+
+# Read stdin to avoid broken pipe
+output=$(cat)
+tool_name=$(echo "$output" | jq -r '.tool_name // empty' 2>/dev/null || true)
+
+echo "[hook:post-tool-use] tool=$tool_name"
+
+exit 0

--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 # Hook: PostToolUse
 # Fires after every tool call. Receives the tool output as JSON on stdin.
-#
-# Stub — no post-tool action needed for libro-client development.
+# IMPORTANT: This fires on EVERY tool call. Keep it fast and silent.
 
 set -euo pipefail
 
-# Read stdin to avoid broken pipe
 output=$(cat)
-tool_name=$(echo "$output" | jq -r '.tool_name // empty' 2>/dev/null || true)
-
-echo "[hook:post-tool-use] tool=$tool_name"
 
 exit 0

--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Hook: PreToolUse
+# Fires before every tool call. Receives the tool input as JSON on stdin.
+#
+# Logs the tool name for auditing. Exits 0 to allow all tool calls to proceed.
+#
+# Exit codes:
+#   0 — allow the tool call to proceed
+#   2 — block the tool call (Claude sees your stderr output as the reason)
+
+set -euo pipefail
+
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+
+echo "[hook:pre-tool-use] tool=$tool_name"
+
+exit 0

--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 # Hook: PreToolUse
 # Fires before every tool call. Receives the tool input as JSON on stdin.
-#
-# Logs the tool name for auditing. Exits 0 to allow all tool calls to proceed.
-#
-# Exit codes:
-#   0 — allow the tool call to proceed
-#   2 — block the tool call (Claude sees your stderr output as the reason)
+# IMPORTANT: This fires on EVERY tool call. Keep it fast and silent.
+# Exit 0 = allow, exit 2 = block (stderr message shown to Claude).
 
 set -euo pipefail
 
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
 
-echo "[hook:pre-tool-use] tool=$tool_name"
+# Example: block dangerous rm commands
+# command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+# if [ "$tool_name" = "Bash" ] && echo "$command" | grep -q 'rm -rf /'; then
+#   echo "Blocked: dangerous rm command" >&2
+#   exit 2
+# fi
 
 exit 0

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # Hook: SessionEnd
-# Fires when the Claude Code session terminates.
-#
-# Stub — no cleanup needed for libro-client development.
-
-set -euo pipefail
-
-echo "[hook:session-end] Session ending"
+# Fires when the session terminates.
 
 exit 0

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Hook: SessionEnd
+# Fires when the Claude Code session terminates.
+#
+# Stub — no cleanup needed for libro-client development.
+
+set -euo pipefail
+
+echo "[hook:session-end] Session ending"
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,28 +5,28 @@
 # Installs bun if not present (needed for Claude Code Web ephemeral containers).
 # Then runs bun install to ensure dependencies are up to date.
 
-set -euo pipefail
+set +e  # Never exit on error in session-start
 
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  echo "[hook:session-start] Running in Claude Code Web (ephemeral container)"
+  echo "[session-start] Running in Claude Code Web (ephemeral container)" >&2
 
   # Install bun if not present
   if ! command -v bun &>/dev/null; then
-    echo "[hook:session-start] Installing bun..."
+    echo "[session-start] Installing bun..." >&2
     curl -fsSL https://bun.sh/install | bash
     export PATH="/root/.bun/bin:${PATH}"
   else
-    echo "[hook:session-start] bun already installed: $(bun --version)"
+    echo "[session-start] bun already installed: $(bun --version)" >&2
   fi
 else
-  echo "[hook:session-start] Running in local devcontainer — tools pre-installed"
+  echo "[session-start] Running in local devcontainer — tools pre-installed" >&2
 fi
 
 # Install dependencies
 if [ -f "${CLAUDE_PROJECT_DIR}/package.json" ]; then
-  echo "[hook:session-start] Running bun install..."
+  echo "[session-start] Running bun install..." >&2
   cd "${CLAUDE_PROJECT_DIR}" && bun install
 fi
 
-echo "[hook:session-start] Done"
+echo "[session-start] Done" >&2
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Hook: SessionStart
+# Fires once when a fresh Claude Code session begins (not on resume).
+#
+# Installs bun if not present (needed for Claude Code Web ephemeral containers).
+# Then runs bun install to ensure dependencies are up to date.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  echo "[hook:session-start] Running in Claude Code Web (ephemeral container)"
+
+  # Install bun if not present
+  if ! command -v bun &>/dev/null; then
+    echo "[hook:session-start] Installing bun..."
+    curl -fsSL https://bun.sh/install | bash
+    export PATH="/root/.bun/bin:${PATH}"
+  else
+    echo "[hook:session-start] bun already installed: $(bun --version)"
+  fi
+else
+  echo "[hook:session-start] Running in local devcontainer — tools pre-installed"
+fi
+
+# Install dependencies
+if [ -f "${CLAUDE_PROJECT_DIR}/package.json" ]; then
+  echo "[hook:session-start] Running bun install..."
+  cd "${CLAUDE_PROJECT_DIR}" && bun install
+fi
+
+echo "[hook:session-start] Done"
+exit 0

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 # Hook: Stop
 # Fires when Claude finishes generating a response.
-#
-# Runs TypeScript type-checking as a final quality check after Claude makes changes.
+# Runs TypeScript type-checking. Blocks (exit 2) on type errors.
 
 set -euo pipefail
 
 if [ -f "${CLAUDE_PROJECT_DIR}/tsconfig.json" ]; then
-  echo "[hook:stop] Running TypeScript type check..."
   if command -v bunx &>/dev/null; then
-    cd "${CLAUDE_PROJECT_DIR}" && bunx tsc --noEmit 2>&1 | tail -30 || {
-      echo "[hook:stop] TypeScript found type errors (exit code $?)"
+    if ! TSC_OUTPUT=$(cd "${CLAUDE_PROJECT_DIR}" && bunx tsc --noEmit 2>&1); then
+      echo "TypeScript type errors found. Fix before continuing:" >&2
+      echo "$TSC_OUTPUT" | tail -30 >&2
       exit 2
-    }
-  else
-    echo "[hook:stop] bunx not installed — skipping type check"
+    fi
   fi
 fi
 

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Hook: Stop
+# Fires when Claude finishes generating a response.
+#
+# Runs TypeScript type-checking as a final quality check after Claude makes changes.
+
+set -euo pipefail
+
+if [ -f "${CLAUDE_PROJECT_DIR}/tsconfig.json" ]; then
+  echo "[hook:stop] Running TypeScript type check..."
+  if command -v bunx &>/dev/null; then
+    cd "${CLAUDE_PROJECT_DIR}" && bunx tsc --noEmit 2>&1 | tail -30 || {
+      echo "[hook:stop] TypeScript found type errors (exit code $?)"
+      exit 2
+    }
+  else
+    echo "[hook:stop] bunx not installed — skipping type check"
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/subagent-stop.sh
+++ b/.claude/hooks/subagent-stop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Hook: SubagentStop
+# Fires when a subagent (spawned via the Agent tool) finishes its turn.
+#
+# Stub — no subagent coordination needed for libro-client development.
+
+set -euo pipefail
+
+echo "[hook:subagent-stop] Subagent finished"
+
+exit 0

--- a/.claude/hooks/subagent-stop.sh
+++ b/.claude/hooks/subagent-stop.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # Hook: SubagentStop
-# Fires when a subagent (spawned via the Agent tool) finishes its turn.
-#
-# Stub — no subagent coordination needed for libro-client development.
-
-set -euo pipefail
-
-echo "[hook:subagent-stop] Subagent finished"
+# Fires when a subagent finishes.
 
 exit 0

--- a/.claude/rules/DOCUMENTATION.md
+++ b/.claude/rules/DOCUMENTATION.md
@@ -1,0 +1,33 @@
+# Documentation
+
+## Mandatory Docs
+
+| File | Content |
+|------|---------|
+| `README.md` | What it is, quickstart, badges |
+| `docs/architecture.md` | System design, component map |
+| `docs/configuration.md` | All env vars — type, default, description |
+| `docs/deployment/kubernetes.md` | K8s deployment reference |
+| `docs/security.md` | Permission model, trust boundaries |
+| `docs/api.md` | HTTP API reference (if applicable) |
+
+## Update Triggers
+
+| Change | Doc to Update |
+|--------|--------------|
+| New env var | `docs/configuration.md` |
+| New HTTP endpoint | `docs/api.md` |
+| Architecture change | `docs/architecture.md` |
+| New K8s mounts/ports | `docs/deployment/kubernetes.md` |
+| Security model change | `docs/security.md` |
+
+## `docs/planned/` — Draft Specs
+
+Committed design docs for unimplemented features. Set `status: done` when shipped — never
+delete specs. Keep `docs/planned/index.md` in sync when specs are added or ship.
+
+## PR Checklist
+- [ ] New env vars in `docs/configuration.md`
+- [ ] New endpoints in `docs/api.md`
+- [ ] `planned/index.md` updated if spec shipped or added
+- [ ] No stale references to renamed config keys

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bun install:*)",
+      "Bash(bun add:*)",
+      "Bash(bun remove:*)",
+      "Bash(bun run:*)",
+      "Bash(bun build:*)",
+      "Bash(bun check:*)",
+      "Bash(bunx tsc:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(wc:*)",
+      "Bash(tree:*)",
+      "Bash(jq:*)",
+      "Bash(git log:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(sort:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop.sh\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/subagent-stop.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor)
-RUN curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64 \
     -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 # Install Bun

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    jq \
+    ca-certificates \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install yq (YAML processor)
+RUN curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+    -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+# Install Bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "libro-client",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "postStartCommand": "bash /workspace/.devcontainer/entrypoint.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-next"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  },
+  "remoteUser": "root",
+  "features": {}
+}

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Devcontainer entrypoint
+# Runs after the container starts. Installs bun dependencies.
+
+set -euo pipefail
+
+WORKSPACE="/workspace"
+
+echo "[entrypoint] Setting up libro-client devcontainer..."
+
+# Install dependencies
+if [ -f "${WORKSPACE}/package.json" ]; then
+  echo "[entrypoint] Installing bun dependencies..."
+  cd "${WORKSPACE}" && bun install
+else
+  echo "[entrypoint] No package.json found — skipping bun install"
+fi
+
+echo "[entrypoint] Devcontainer ready"

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,19 +1,30 @@
 #!/bin/bash
-# Devcontainer entrypoint
-# Runs after the container starts. Installs bun dependencies.
+# Devcontainer entrypoint - runs on every container start.
+# Keep this idempotent (safe to run multiple times).
 
 set -euo pipefail
 
-WORKSPACE="/workspace"
+echo "=== Libro Devcontainer Health Check ==="
 
-echo "[entrypoint] Setting up libro-client devcontainer..."
+# Tool version validation
+check_tool() {
+  local name="$1"
+  local cmd="$2"
+  if version=$($cmd 2>/dev/null); then
+    printf "  %-18s %s\n" "$name" "$version"
+  else
+    printf "  %-18s %s\n" "$name" "NOT FOUND"
+  fi
+}
+
+echo "Tools:"
+check_tool "bun" "bun --version"
+check_tool "node" "node --version"
+check_tool "yq" "yq --version"
+
+echo "=== Health Check Complete ==="
 
 # Install dependencies
-if [ -f "${WORKSPACE}/package.json" ]; then
-  echo "[entrypoint] Installing bun dependencies..."
-  cd "${WORKSPACE}" && bun install
-else
-  echo "[entrypoint] No package.json found — skipping bun install"
+if [ -f package.json ]; then
+  bun install --silent 2>/dev/null || true
 fi
-
-echo "[entrypoint] Devcontainer ready"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# libro-client
+
+Audiobook downloader and service for Libro.fm. Downloads audiobooks from the Libro.fm API, tracks local state, and supports both interactive CLI usage and automated service mode.
+
+## Quick Start
+
+```bash
+# Install dependencies
+bun install
+
+# Type check (no emit)
+bunx tsc --noEmit
+
+# Run CLI
+bun run cli.ts <command>
+
+# Run as background service (polls every 30s)
+bun run service.ts
+
+# Build standalone binary
+bun run build:cli
+
+# Build Docker image
+bun run build:docker
+```
+
+## Architecture
+
+```
+cli.ts              — CLI entry point (yargs commands: list, get, check)
+service.ts          — Long-running service (polls for new books every 30s)
+src/
+  LibroFmClient.ts  — Main client: login, getLibrary, downloadBook, getNewBooks
+  APIHandler.ts     — HTTP layer: login, library, download-manifest endpoints
+  lib/
+    Config.ts       — Credentials config (env vars + JSON file in data/config/)
+    Directories.ts  — Path constants (data/, downloads/, logs/, cache/, config/)
+    DownloadClient.ts — File download + zip extraction
+    InputHandler.ts — Interactive prompts (@inquirer/* for credentials, selection)
+    Logger.ts       — Winston logger + @LogMethod decorator
+    State.ts        — Local book state (data/config/state.json)
+  types.d.ts        — Global TypeScript types (Audiobook, AudiobookMap, etc.)
+```
+
+### Data Flow
+
+1. `Config` loads credentials from env (`LIBROFM_USERNAME`, `LIBROFM_PASSWORD`) or `data/config/config.json`
+2. `LibroFmClient.init()` logs in via `APIHandler` if no authToken, saves token to config
+3. CLI commands call `client.getLibrary()` -> `APIHandler.fetchLibrary()` -> paginated API
+4. `client.downloadBook()` -> `APIHandler.fetchDownloadMetadata()` -> `DownloadClient.downloadFiles()`
+5. `State` tracks downloaded ISBNs in `data/config/state.json`
+
+### External Dependencies
+
+- **Libro.fm API**: `https://libro.fm` — OAuth2 password grant, REST endpoints
+- **Bun**: Runtime and bundler (no Node.js required)
+- **TypeScript**: Strict mode, `noEmit: true`, path alias `@/*` -> `src/*`
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LIBROFM_USERNAME` | No | Libro.fm account email (fallback to interactive prompt) |
+| `LIBROFM_PASSWORD` | No | Libro.fm account password (fallback to interactive prompt) |
+
+Credentials are persisted to `data/config/config.json` after first successful login. Auth tokens are also cached there.
+
+## Hooks
+
+Hooks live in `.claude/hooks/` and fire at key points in Claude Code sessions.
+
+- `session-start.sh` — Detects Claude Code Web; installs bun if missing, then runs `bun install`
+- `pre-tool-use.sh` — Logs tool name; exits 0 (no blocking)
+- `post-tool-use.sh` — Stub; no auto-formatter configured yet
+- `stop.sh` — Runs `bunx tsc --noEmit` to type-check after every response
+- `subagent-stop.sh` — Stub
+- `session-end.sh` — Stub


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with project overview, quick start commands, architecture diagram, environment variables, and hook documentation
- Adds `.devcontainer/` with Ubuntu 24.04 Dockerfile (git, curl, jq, yq, Bun), `devcontainer.json`, and `entrypoint.sh` (runs `bun install` on container start)
- Adds all 6 Claude Code hooks in `.claude/hooks/` (session-start installs bun in Claude Code Web, stop runs `bunx tsc --noEmit` as blocking type-check)
- Updates `.claude/settings.json` to register all 6 hook events alongside existing bun/tsc permissions
- Adds `.pre-commit-config.yaml` with basic pre-commit-hooks (trailing whitespace, end-of-file, JSON/YAML checks, merge conflict detection)
- Preserves existing `.claude/rules/DOCUMENTATION.md`

## Test plan

- [ ] Open repo in Claude Code Web — `session-start.sh` should install bun and run `bun install`
- [ ] Make a TypeScript change with a type error — `stop.sh` should report the error and exit 2
- [ ] Open devcontainer locally — `entrypoint.sh` should run `bun install` automatically
- [ ] Run `pre-commit run --all-files` to verify hooks pass on clean code

🤖 Generated with [Claude Code](https://claude.com/claude-code)