### PR TITLE
feat: custom download directory and series-based file organization

### DIFF
--- a/src/LibroFmClient.ts
+++ b/src/LibroFmClient.ts
@@ -29,6 +29,14 @@ export default class LibroFmClient {
 			}
 			await this.login(this.config.username, this.config.password);
 		}
+		if (!this.config.downloadDir) {
+			const downloadDir = await InputHandler.requestDownloadLocation();
+			this.config.change({ downloadDir });
+
+			if (!this.config.downloadDir) {
+				throw new Error("Download directory not provided");
+			}
+		}
 	}
 
 	/** Logs in to the Libro.fm API and saves the authToken in the config. */
@@ -103,16 +111,28 @@ export default class LibroFmClient {
 
 		try {
 			if (!book.authors) throw new Error("No authors found");
-			const filename =
+			const authors =
 				typeof book.authors === "string"
 					? book.authors
 					: book.authors.join(", ");
+
+			const series =
+				typeof book.series === "string" ? book.series : null;
+
+			const title = [book.series_num, book.title]
+				.filter(Boolean)
+				.join(" - ");
+
+			const filename = [authors, series, title]
+				.filter(Boolean)
+				.join("/");
 
 			const [path, zipped_files] = await DownloadCLient.downloadFiles(
 				filename,
 				urls,
 				authToken,
-				keepZip
+				keepZip,
+				this.config.downloadDir
 			);
 
 			await DownloadCLient.saveMetadata(book, metadata, path);

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -4,6 +4,7 @@ import { LogMethod } from "./Logger";
 
 const USERNAME = process.env.LIBROFM_USERNAME;
 const PASSWORD = process.env.LIBROFM_PASSWORD;
+const DOWNLOAD_DIR = process.env.LIBROFM_DOWNLOAD_DIR;
 
 const scope = "Config";
 
@@ -12,6 +13,7 @@ export default class Config {
 	username: string | undefined;
 	password: string | undefined;
 	authToken: string | undefined;
+	downloadDir: string | undefined;
 
 	constructor(config?: Partial<Config>) {
 		this.load();
@@ -45,6 +47,7 @@ export default class Config {
 	private loadEnv(override = false): void {
 		if (override || !this.username) this.username = USERNAME;
 		if (override || !this.password) this.password = PASSWORD;
+		if (override || !this.downloadDir) this.downloadDir = DOWNLOAD_DIR;
 	}
 
 	/** Saves the config to the file system */

--- a/src/lib/DownloadClient.ts
+++ b/src/lib/DownloadClient.ts
@@ -20,7 +20,8 @@ export default class DownloadCLient {
 		filename: string,
 		urls: string[],
 		authToken: string,
-		keepZip = false
+		keepZip = false,
+		directory?: string,
 	): Promise<[string, string[] | false]> {
 		const buffers = await Promise.all(
 			urls.map((url) => DownloadCLient.download(url, authToken))
@@ -39,7 +40,7 @@ export default class DownloadCLient {
 			)
 		);
 
-		const finalPath = path.join(DOWNLOAD_DIR, filename);
+		const finalPath = path.join(directory || DOWNLOAD_DIR, filename);
 		await DownloadCLient.mergeDirectories(paths, finalPath);
 
 		return [finalPath, zipped_files];
@@ -113,7 +114,7 @@ export default class DownloadCLient {
 			const outputPath = path.join(CACHE_DIR, outputDir);
 
 			if (!fs.existsSync(outputPath)) {
-				fs.mkdirSync(outputPath);
+				fs.mkdirSync(outputPath, { recursive: true });
 			}
 
 			const filePromises: Promise<void>[] = [];
@@ -153,7 +154,7 @@ export default class DownloadCLient {
 		});
 		try {
 			if (!fs.existsSync(dest)) {
-				fs.mkdirSync(dest);
+				fs.mkdirSync(dest, { recursive: true });
 			}
 
 			for (const dir of src) {

--- a/src/lib/InputHandler.ts
+++ b/src/lib/InputHandler.ts
@@ -22,6 +22,13 @@ export default class InputHandler {
 		return { username, password: pass };
 	};
 
+	static requestDownloadLocation = async (): Promise<string> => {
+		const location = await input({
+			message: "Enter the full path to your download location",
+		});
+		return location;
+	};
+
 	/** Requests the user to select a book to download */
 	static requestDownloadChoice = async (
 		audiobooks: Audiobook[]


### PR DESCRIPTION
## Summary

- Add configurable download directory via `LIBROFM_DOWNLOAD_DIR` env var or interactive prompt
- Organize downloads as `Author(s)/Series/SeriesNum - Title/` when series info is available
- Make `mkdirSync` recursive to support nested directory creation

Closes #6

Based on work by @megawubs in #7, rebased and reformatted for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)