### PR TITLE
fix: handle first release with no prior tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,11 @@ jobs:
             LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n1 || true)
 
             if [ -z "$LATEST_TAG" ]; then
-              MAJOR=0; MINOR=0; PATCH=0
+              # No tags yet — seed from package.json version
+              PKG_VERSION=$(jq -r '.version' package.json)
+              MAJOR=$(echo "$PKG_VERSION" | cut -d. -f1)
+              MINOR=$(echo "$PKG_VERSION" | cut -d. -f2)
+              PATCH=$(echo "$PKG_VERSION" | cut -d. -f3)
             else
               LATEST_VERSION="${LATEST_TAG#v}"
               MAJOR=$(echo "$LATEST_VERSION" | cut -d. -f1)
@@ -149,14 +153,20 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | grep -B1 "^${TAG}$" | head -1)
-          if [ "$PREV_TAG" = "$TAG" ]; then
-            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
-          fi
-          gh release create "$TAG" \
-            --title "Release ${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            --notes-start-tag "$PREV_TAG" \
+
+          RELEASE_ARGS=(
+            "$TAG"
+            --title "Release ${{ steps.version.outputs.version }}"
+            --generate-notes
             --latest
+          )
+
+          # Only add --notes-start-tag if a valid previous tag exists
+          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+            RELEASE_ARGS+=(--notes-start-tag "$PREV_TAG")
+          fi
+
+          gh release create "${RELEASE_ARGS[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

- Seed version from `package.json` when no git tags exist (first release will be `v0.0.8`, not `v0.0.1`)
- Skip `--notes-start-tag` when there's no valid previous tag (fixes the `gh release create` failure)

Fixes the release workflow failure from #12: https://github.com/jedwards1230/libro-client/actions/runs/23412331011

## Test plan

- [ ] Merge → next release workflow creates `v0.0.8` successfully
- [ ] Docker image pushed as `jedwards1230/libro:0.0.8` + `latest`