### PR TITLE
fix: explicitly dispatch publish-npm.yml from release.yml + Dockerfile casing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,6 +472,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write  # required for `gh workflow run publish-npm.yml`
     steps:
       - name: Compose release body (install snippets + AI notes)
         env:
@@ -508,6 +509,16 @@ jobs:
           body_path: /tmp/release_body.md
           make_latest: true
 
+      - name: Trigger npm publish workflow
+        # The `release: published` event won't fire publish-npm.yml when the
+        # release is created by GITHUB_TOKEN (GitHub's anti-recursion safety),
+        # so we dispatch it explicitly. workflow_dispatch from GITHUB_TOKEN
+        # does cross workflow boundaries.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: gh workflow run publish-npm.yml --repo "${{ github.repository }}" --ref main --field tag="$TAG"
+
       - name: Summary
         env:
           TAG: ${{ needs.prepare.outputs.tag }}
@@ -523,5 +534,5 @@ jobs:
             echo "| Bump | ${BUMP_TYPE} |"
             echo "| Image | \`jedwards1230/libro:${VERSION}\` |"
             echo ""
-            echo "npm publishing is handled by \`publish-npm.yml\`, triggered automatically by the release event."
+            echo "npm publishing dispatched to \`publish-npm.yml\` for tag \`${TAG}\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 as base
+FROM oven/bun:1 AS base
 WORKDIR /app
 
 FROM base AS install


### PR DESCRIPTION
## Summary

Two small fixes uncovered by the first real release run after [#17](https://github.com/jedwards1230/libro-client/pull/17) landed.

### 1. publish-npm.yml never ran after v0.0.4

[release.yml run](https://github.com/jedwards1230/libro-client/actions/runs/25996043156) succeeded end-to-end (tag, Docker push, GH Release), but [publish-npm.yml](https://github.com/jedwards1230/libro-client/actions/workflows/publish-npm.yml) shows zero runs.

**Root cause:** GitHub Actions suppresses `release: published` events that are triggered by `GITHUB_TOKEN` — anti-recursion safety per [the docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). Since `softprops/action-gh-release@v3` creates the release using `GITHUB_TOKEN`, the resulting `release: published` event is dropped.

**Fix:** Explicitly dispatch `publish-npm.yml` from the `release` job after the GH Release lands. `workflow_dispatch` from `GITHUB_TOKEN` *does* cross workflow boundaries.

```yaml
- name: Trigger npm publish workflow
  env:
    GH_TOKEN: ${{ github.token }}
    TAG: ${{ needs.prepare.outputs.tag }}
  run: gh workflow run publish-npm.yml --repo "${{ github.repository }}" --ref main --field tag="$TAG"
```

Also bumps the `release` job permissions: `actions: write` (required for `gh workflow run`).

`publish-npm.yml`'s `release: published` trigger is **kept** so that releases created via the GitHub UI (which use a PAT, not `GITHUB_TOKEN`) still chain automatically — the explicit dispatch just adds a second, reliable path for releases created by the workflow itself.

### 2. Dockerfile `FromAsCasing` warning

Docker BuildKit warning from the v0.0.4 build:

```
The 'as' keyword should match the case of the 'from' keyword: Dockerfile#L1
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```

Line 1 used `as` (lowercase) while the other two stage definitions used `AS`. Normalized to uppercase.

## v0.0.4 — needs manual publish

This PR fixes the chain going forward (next merge → v0.0.5 will publish automatically). v0.0.4 itself missed npm because the chain wasn't fixed yet. Will be manually backfilled via:

```bash
gh workflow run publish-npm.yml -R jedwards1230/libro-client --field tag=v0.0.4 --field dry_run=false
```

## Test plan

- [x] YAML structure valid (`yq eval '.jobs.release.steps[].name'` lists the new step in the right position).
- [x] Dockerfile parses (single-line change, idempotent).
- [ ] Manual dispatch of `publish-npm.yml` for v0.0.4 — verifies Trusted Publishing OIDC setup works against the real npm registry.
- [ ] Next release (post-merge): merge this PR with `semver:patch` → v0.0.5 → Docker push → GH Release → `publish-npm.yml` triggers automatically via the new `gh workflow run` step.