### PR TITLE
docs: fix stale documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ Audiobook downloader and service for Libro.fm. Downloads audiobooks from the Lib
 # Install dependencies
 bun install
 
+# Run tests
+bun test
+
 # Type check (no emit)
 bunx tsc --noEmit
 
@@ -75,12 +78,6 @@ reference is [burntcookie90/librofm-downloader](https://github.com/burntcookie90
 - When auth breaks, first test `/oauth/token` with `curl` using the headers from
   burntcookie90's Dockerfile; if that succeeds, update `APIHandler.ts` to match.
 
-## Docs
-
-No `docs/` tree — `README.md` is for users (CLI usage, install, env), `CLAUDE.md`
-is for sessions (architecture, gotchas, hooks). Don't add a `docs/` tree unless a
-real long-form spec needs one.
-
 ## Environment Variables
 
 | Variable | Required | Description |
@@ -90,13 +87,3 @@ real long-form spec needs one.
 
 Credentials are persisted to `data/config/config.json` after first successful login. Auth tokens are also cached there.
 
-## Hooks
-
-Hooks live in `.claude/hooks/` and fire at key points in Claude Code sessions.
-
-- `session-start.sh` — Detects Claude Code Web; installs bun if missing, then runs `bun install`
-- `pre-tool-use.sh` — Logs tool name; exits 0 (no blocking)
-- `post-tool-use.sh` — Stub; no auto-formatter configured yet
-- `stop.sh` — Runs `bunx tsc --noEmit` to type-check after every response
-- `subagent-stop.sh` — Stub
-- `session-end.sh` — Stub

--- a/README.md
+++ b/README.md
@@ -11,19 +11,18 @@ This is a simple command-line tool for interacting with your Libro.fm library. I
 
 ### Installation
 
-The CLI can be installed as a global package using npm:
+Build the standalone CLI binary (requires [Bun](https://bun.sh)):
 
 ```bash
-bun add -g libro-client
+bun install
+bun run build:cli   # outputs bin/libro
 ```
 
-To run the tool, use the following command:
+Then either run `bin/libro` directly or add `bin/` to your `PATH`:
 
 ```bash
-libro
+./bin/libro
 ```
-
-This will display a list of available commands.
 
 ### List audiobooks
 
@@ -90,9 +89,9 @@ docker-compose up -d
 You can set the following environment variables:
 
 ```bash
-DEBUG=false
-LIBROFM_USERNAME=<your_librofm_username>
-LIBROFM_PASSWORD=<your_librofm_password>
+DEBUG=true                          # enable debug-level logging (default: off)
+LIBROFM_USERNAME=<your_username>    # Libro.fm account email
+LIBROFM_PASSWORD=<your_password>    # Libro.fm account password
 ```
 
 ## Disclaimer


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Removed phantom `## Hooks` section — `.claude/` contains only `settings.json`, no `hooks/` directory exists
- **CLAUDE.md**: Removed `## Docs` section — author-to-self meta-commentary with no contributor value
- **CLAUDE.md**: Added `bun test` to Quick Start command list — test suite (`src/__tests__/`, 7 files) runs in CI but was undocumented
- **README.md**: Replaced `bun add -g libro-client` global-install instructions with the real build workflow (`bun run build:cli` → `bin/libro`) — the `bin.libro` field points at `cli.ts` (TypeScript source), which is not executable as an installed binary
- **README.md**: Fixed `DEBUG` env var documentation — `DEBUG=false` was misleading; `DEBUG` is a flag read by `Logger.ts` that enables debug-level logging when set to `true`

## Findings that did NOT need fixing

None — all five reported findings were confirmed against the code.