### PR TITLE
fix: stop headless 1-core busy-spin from interactive prompts

### DIFF
--- a/src/LibroFmClient.ts
+++ b/src/LibroFmClient.ts
@@ -4,6 +4,7 @@ import APIHandler from "@/APIHandler";
 import logger, { LogMethod } from "@/lib/Logger";
 import Config from "@/lib/Config";
 import State from "@/lib/State";
+import { DOWNLOAD_DIR } from "@/lib/Directories";
 
 const scope = "LibroFmClient";
 
@@ -30,7 +31,14 @@ export default class LibroFmClient {
 			await this.login(this.config.username, this.config.password);
 		}
 		if (!this.config.downloadDir) {
-			const downloadDir = await InputHandler.requestDownloadLocation();
+			// In a non-interactive (headless/service) environment there is no
+			// TTY to answer a prompt — fall back to the default downloads
+			// directory instead of spinning the event loop forever on an
+			// @inquirer prompt that can never resolve. Interactive callers are
+			// still prompted as before.
+			const downloadDir = process.stdin.isTTY
+				? await InputHandler.requestDownloadLocation()
+				: DOWNLOAD_DIR;
 			this.config.change({ downloadDir });
 
 			if (!this.config.downloadDir) {

--- a/src/__tests__/InputHandler.test.ts
+++ b/src/__tests__/InputHandler.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import InputHandler from "@/lib/InputHandler";
+
+/**
+ * Regression guard for the headless 1-core busy-spin: when stdin is not a TTY,
+ * the interactive @inquirer prompts must throw immediately instead of hanging
+ * (which previously spun the event loop at 100% of a CPU core indefinitely).
+ */
+describe("InputHandler non-TTY guards", () => {
+	const original = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+
+	const setTTY = (value: boolean | undefined): void => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value,
+			configurable: true,
+		});
+	};
+
+	afterEach(() => {
+		if (original) {
+			Object.defineProperty(process.stdin, "isTTY", original);
+		} else {
+			setTTY(undefined);
+		}
+	});
+
+	test("requestCredentials throws without a TTY instead of hanging", async () => {
+		setTTY(undefined);
+		await expect(InputHandler.requestCredentials()).rejects.toThrow(
+			/not a TTY/i
+		);
+	});
+
+	test("requestDownloadLocation throws without a TTY", async () => {
+		setTTY(false);
+		await expect(InputHandler.requestDownloadLocation()).rejects.toThrow(
+			/not a TTY/i
+		);
+	});
+
+	test("requestDownloadChoice throws without a TTY", async () => {
+		setTTY(false);
+		await expect(
+			InputHandler.requestDownloadChoice([
+				{ isbn: "001", title: "Test Book" },
+			])
+		).rejects.toThrow(/not a TTY/i);
+	});
+
+	test("requestOverwrite throws without a TTY", async () => {
+		setTTY(false);
+		await expect(
+			InputHandler.requestOverwrite({ isbn: "001", title: "Test Book" })
+		).rejects.toThrow(/not a TTY/i);
+	});
+});

--- a/src/lib/InputHandler.ts
+++ b/src/lib/InputHandler.ts
@@ -8,10 +8,28 @@ type Credentials = {
 	password: string;
 };
 
+/**
+ * Guards an interactive prompt against a non-interactive (non-TTY) environment.
+ *
+ * When stdin is not a TTY (e.g. a container with stdin bound to /dev/null), the
+ * @inquirer readline prompts never receive input and spin the event loop at
+ * 100% of a CPU core indefinitely. Throwing here turns that silent hang into a
+ * clear, actionable error instead.
+ */
+const ensureInteractive = (what: string): void => {
+	if (!process.stdin.isTTY) {
+		throw new Error(
+			`Cannot prompt for ${what}: stdin is not a TTY (non-interactive environment). ` +
+				`Provide it via configuration or environment variables instead.`
+		);
+	}
+};
+
 /** Helper class for handling user input */
 export default class InputHandler {
 	/** Requests the user's libro.fm credentials (username/password) */
 	static requestCredentials = async (): Promise<Credentials> => {
+		ensureInteractive("libro.fm credentials");
 		const username = await input({
 			message: "Enter your libro.fm username",
 		});
@@ -23,6 +41,7 @@ export default class InputHandler {
 	};
 
 	static requestDownloadLocation = async (): Promise<string> => {
+		ensureInteractive("download location");
 		const location = await input({
 			message: "Enter the full path to your download location",
 		});
@@ -33,6 +52,7 @@ export default class InputHandler {
 	static requestDownloadChoice = async (
 		audiobooks: Audiobook[]
 	): Promise<string> => {
+		ensureInteractive("audiobook selection");
 		const answer = await select({
 			message: "Select an audiobook to download",
 			choices: audiobooks.map((ab, idx) => ({
@@ -45,6 +65,7 @@ export default class InputHandler {
 	};
 
 	static requestOverwrite = async (book: Audiobook): Promise<boolean> => {
+		ensureInteractive("overwrite confirmation");
 		const answer = await confirm({
 			message: `${book.title} already exists. Overwrite?`,
 		});


### PR DESCRIPTION
## Problem

The `libro` service pod was pegged at **~1.0 CPU core for 46h straight** (0 restarts, `Running`/`1/1 Ready`) while doing nothing — it never scanned or downloaded a single book.

**Root cause:** run as a service, stdin is bound to `/dev/null` (non-TTY). With `downloadDir` unset (it's sourced only from `LIBROFM_DOWNLOAD_DIR`, which the deployment doesn't set), `LibroFmClient.init()` fell through to `InputHandler.requestDownloadLocation()` — an `@inquirer` prompt. Its readline loop against an immediately-EOF non-TTY stdin spins the event loop at 100% of one core indefinitely. The service loop after `init()` was never reached, so the pod looked healthy but was a no-op burning a core.

Same *shape* as the Libation silent-scan-stall pattern (Running/Ready, no logs, silent hot loop) — here the cause is an interactive prompt in a headless container, not a scanner.

## Fix

1. **Make it work headless.** `init()` now falls back to the default `DOWNLOAD_DIR` (`<project>/downloads`, which is the mounted `/app/downloads` books volume in the deployment) when stdin is not a TTY, instead of prompting. Interactive callers are still prompted exactly as before.
2. **Fail loud, not silent.** `InputHandler` now guards every prompt on `process.stdin.isTTY` and throws a clear, actionable error in a non-interactive environment — so a future missing config surfaces as a logged error / CrashLoop instead of a silent 1-core spin. This also covers the credentials prompt if env creds are ever missing/expired.
3. **Regression tests** for the non-TTY guards (`src/__tests__/InputHandler.test.ts`).

## Verification

- `bun test` — **69 pass / 0 fail** (8 files, incl. 4 new InputHandler tests).
- `bunx tsc --noEmit` — no new errors (14 pre-existing errors in `APIHandler.test.ts` / `Config.test.ts` mock typings, unchanged by this PR).

## Deploy follow-up (separate, not in this PR)

This is a code fix — it needs a new image build and a tag bump in `homelab-k8s` (`apps/media/libro`, currently pinned `jedwards1230/libro:0.1.0`) to take effect. No ConfigMap change is required: `/app/downloads` is already the mounted books volume, which is what the new default resolves to.

🤖 Generated with [Claude Code](https://claude.ai/code)