### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,17 @@
+@CONTRIBUTING.md
+
 # libro-client
 
 Audiobook downloader and service for Libro.fm. Downloads audiobooks from the Libro.fm API, tracks local state, and supports both interactive CLI usage and automated service mode.
 
-## Quick Start
+## Running locally
 
 ```bash
-# Install dependencies
-bun install
-
-# Run tests
-bun test
-
-# Type check (no emit)
-bunx tsc --noEmit
-
 # Run CLI
 bun run cli.ts <command>
 
 # Run as background service (polls every 30s)
 bun run service.ts
-
-# Build standalone binary
-bun run build:cli
-
-# Build Docker image
-bun run build:docker
 ```
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to libro-client
+
+libro-client is a Bun-based CLI and background service that downloads audiobooks from the Libro.fm API, tracks local state, and runs either interactively or in automated service mode. All changes go through the workflow below.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) — runtime and bundler (no Node.js required for the app itself).
+- Docker — only needed to build/run the container image.
+
+The repository ships a devcontainer (`.devcontainer/`) with the full toolchain preinstalled — opening the repo in it is the quickest way to get a working environment.
+
+## Build, test & lint
+
+```bash
+bun install              # install dependencies (CI uses --frozen-lockfile)
+bun test                 # run the test suite (this is the gate CI enforces)
+bunx tsc --noEmit        # type-check (strict mode, no emit)
+bun run build:cli        # build the standalone binary -> bin/libro
+bun run build:docker     # build the Docker image
+```
+
+CI runs `bun test` only — type-checking and the builds above are local checks, so run them yourself before pushing.
+
+## Documentation
+
+Keep documentation current as part of the change, not as a follow-up — update the README and any affected docs in the same PR.
+
+## Before you open a PR
+
+- Run the test suite (`bun test`) and the type-checker (`bunx tsc --noEmit`) locally first.
+- Run `pre-commit run --all-files` (this repo uses pre-commit hooks).
+
+## Branching & commits
+
+- Branch off `main`; never commit directly to `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, …).
+- Sign your commits where possible (`git commit -S`).
+- Keep each PR focused; delete dead code rather than commenting it out.
+
+## Pull requests
+
+- Open the PR against `main`.
+- Every PR runs CI. Resolve **all** review threads before the PR is merged.
+- An automated code review runs on each PR; address and resolve its threads like any other review.
+- A PR can be merged once CI is green and all review threads are resolved.
+
+## Releases
+
+Releases are cut automatically when a PR is merged to `main`. The release workflow reads the merged PR's `semver:*` label to decide the bump: `semver:minor` or `semver:major` bump accordingly, and any other merge (including unlabeled) defaults to a **patch** bump. Add the `skip-release` label to a PR to opt out of a release entirely.
+
+A release tags `vX.Y.Z`, builds and pushes the multi-arch Docker image (`jedwards1230/libro:<version>` and `:latest`), generates AI release notes, and publishes the GitHub Release. Publishing the Release then triggers a separate workflow that publishes the `libro-client` package to npm via Trusted Publishing (OIDC). The git tag is authoritative — `package.json` is bumped at build time to match it and is never committed back to `main`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ LIBROFM_USERNAME=<your_username>    # Libro.fm account email
 LIBROFM_PASSWORD=<your_password>    # Libro.fm account password
 ```
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, build/test commands, and the PR workflow.
+
 ## Disclaimer
 
 This tool is not affiliated with Libro.fm in any way. Use it at your own risk.


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` as part of the org-wide rollout standardizing contributor docs across jedwards1230 repos. Three-file division of labor: `CONTRIBUTING.md` owns the human-facing build/test/PR/release workflow, `CLAUDE.md` `@import`s it (first line) and keeps only codebase-unique run commands + architecture/gotchas, and `README.md` links to it.

Release section describes the repo's *actual* mechanism truthfully: the inlined `release.yml` (not the shared `ai-release.yml@v1`) cuts a release on merge to `main`, defaulting to a patch bump unless a `semver:minor`/`semver:major` label is set, with `skip-release` to opt out — then builds the multi-arch Docker image and triggers npm Trusted Publishing.

Incidental gaps observed (flagged, NOT fixed in this PR):
- CI (`ci.yml`) runs `bun test` only — no `tsc --noEmit` or lint step. This is the weakest TS test gate among the active TS repos (type errors and style issues won't fail a PR).
- The release is inlined rather than calling the shared `ai-release.yml@v1`; `release-workflows` is now public, so this is a candidate to migrate to the single-file thin-caller pattern (the workflow's own header comment already notes this as a tracked follow-up).

https://claude.ai/code/session_01Ne5arq8Hg8gHYia5VtmPvE