### PR TITLE
docs: move @CONTRIBUTING.md import below the H1 title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-@CONTRIBUTING.md
-
 # libro-client
+
+@CONTRIBUTING.md
 
 Audiobook downloader and service for Libro.fm. Downloads audiobooks from the Libro.fm API, tracks local state, and supports both interactive CLI usage and automated service mode.
 


### PR DESCRIPTION
The `@CONTRIBUTING.md` import was placed above the H1 title (line 1), but repo-standards convention is for the H1 to come first. This moves the import to line 3, immediately after the H1 — the import resolves regardless of position, so this is a structural/convention fix only.

https://claude.ai/code/session_01Ne5arq8Hg8gHYia5VtmPvE