### PR TITLE
ci: pin actions/checkout to v7.0.0 by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -76,7 +76,7 @@ jobs:
           echo "Publishing ${TAG} (version ${VERSION})"
 
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       release_body: ${{ steps.body.outputs.release_body }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -425,7 +425,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.prepare.outputs.tag }}
 


### PR DESCRIPTION
## Summary

- Pins every `actions/checkout` reference across all workflows to the v7.0.0 commit SHA (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`) for supply-chain hardening.
- No workflow logic changed — only the checkout ref on each step.

## Files changed

- `.github/workflows/ci.yml` — `@v4` → SHA
- `.github/workflows/publish-npm.yml` — `@v6` → SHA
- `.github/workflows/release.yml` — both `@v6` occurrences → SHA (prepare job + docker job)

https://claude.ai/code/session_01UbFYMkLjjvLsU1DjHowC2E