### PR TITLE
ci(pr-review): cancel in-flight review on PR merge/close

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -5,7 +5,7 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, closed]
 
 permissions:
   contents: read
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   review:
+    if: github.event.action != 'closed'
     uses: jedwards1230/release-workflows/.github/workflows/claude-pr-review.yml@v1
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -27,3 +28,11 @@ jobs:
         - Secrets: no API keys/tokens leaked into client bundles or logs.
         - Dependency/supply-chain risk on new deps.
         Do NOT re-flag eslint/prettier/tsc — CI owns those.
+
+  cancel-review:
+    if: github.event.action == 'closed'
+    permissions:
+      actions: write
+    uses: jedwards1230/release-workflows/.github/workflows/claude-pr-review-cancel.yml@v1
+    with:
+      review_workflow: "PR Review"


### PR DESCRIPTION
## Summary
- GitHub doesn't auto-cancel an in-flight Claude PR-review run when its PR merges/closes — it otherwise runs to completion, burns tokens, and posts comments onto an already-merged PR.
- Adds `closed` to the review workflow's PR trigger types, guards the review job off `closed` events, and adds a `cancel-review` job calling the shared `claude-pr-review-cancel.yml@v1` reusable to cancel in-flight runs.
- This workflow's display name is `PR Review` (not the reusable's default), so the cancel job passes `review_workflow: "PR Review"` to match the right runs.
- Mirrors the pattern already live in `jedwards1230/homelab-k8s`.

## Test plan
- [ ] actionlint clean on the changed file
- [ ] Merge a throwaway PR and confirm a mid-flight review run gets cancelled, with no false-positive cancellation on normal opened/synchronize events