### PR TITLE
ci: prefer CLAUDE_CODE_OAUTH_TOKEN for Claude reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,7 @@ jobs:
     if: github.event.action != 'closed'
     uses: jedwards1230/release-workflows/.github/workflows/claude-pr-review.yml@v1
     secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # preferred (subscription)
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
       focus: |


### PR DESCRIPTION
Pass `CLAUDE_CODE_OAUTH_TOKEN` through to the shared PR-review reusable, which prefers it over `ANTHROPIC_API_KEY` since [release-workflows v1.6.0](https://github.com/jedwards1230/release-workflows/releases/tag/v1.6.0) — reviews bill to the Claude subscription instead of the metered API. The repo secret is already populated (lilbro-tf fanout); the API key remains the fallback, so this is safe to merge any time. Part of the portfolio-wide OAuth rollout.

https://claude.ai/code/session_01LAr17urRi2SJckMgvRGFdf