### PR TITLE
chore: repo-standards remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,17 +429,17 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.tag }}
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
@@ -503,7 +503,7 @@ jobs:
           cat /tmp/ai_body.md >> /tmp/release_body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: Release ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Summary
- Pin third-party GitHub Actions to full commit SHAs (SC-supply-chain hardening): `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`, `softprops/action-gh-release` (release.yml); `actions/setup-node` (publish-npm.yml); `oven-sh/setup-bun` (ci.yml).
- `actions/checkout` was already SHA-pinned; left as-is.
- Left the same-org reusable-workflow calls (`jedwards1230/release-workflows/...@v1`) on their moving major tag per the portfolio's documented convention — `sha_pinning_required` does not gate those.

Post-merge: set `sha_pinning_required=true` on this repo's Actions permissions (deferred until this PR merges, since the default branch still has unpinned refs until then).

## Test plan
- [x] YAML syntax validated (`yq eval`) for all four workflow files
- [x] `actionlint` run — only pre-existing shellcheck warnings unrelated to this change (no new findings from the ref edits)
- [x] Verified every rewritten ref resolves to the correct tag's commit SHA via `gh api repos/<owner>/<action>/commits/<tag>`